### PR TITLE
[API-618] Add Default Conf so Connector Can Load

### DIFF
--- a/conf/default.js
+++ b/conf/default.js
@@ -1,0 +1,11 @@
+module.exports = {
+    connectors: {
+        'appc.redis': {
+            host: '127.0.0.1',
+            port: 6379,
+            opts: {
+                db: 1
+            }
+        }
+    }
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pkginfo": "0.3.0"
   },
   "devDependencies": {
-    "arrow": "0.4.1",
+    "arrow": "0.4.9",
     "blanket": "1.1.6",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",


### PR DESCRIPTION
This helps the included app.js work.

https://jira.appcelerator.org/browse/API-618